### PR TITLE
replace master references with admin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ reported the issue. Please try to include as much information as you can. Detail
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## Centralize AWS GuardDuty
 
-Installing this Customization will enable GuardDuty in all AWS Control Tower managed accounts, with the Audit account acting as the default GuardDuty Master.
+Installing this Customization will enable GuardDuty in all AWS Control Tower managed accounts, with the Audit account acting as the default GuardDuty Admin account.
 
-This is done by deploying a GuardDuty Enabler lambda function in the master account. It runs periodically and checks each Control Tower managed account/region to ensure that they have been invited into the master GuardDuty account and that GuardDuty is enabled. 
+This is done by deploying a GuardDuty Enabler lambda function in the Control Tower root account. It runs periodically and checks each Control Tower managed account/region to ensure that they have been invited into the GuardDuty Admin account and that GuardDuty is enabled.
 
 ## Attributions
 

--- a/aws-control-tower-guardduty-enabler.template
+++ b/aws-control-tower-guardduty-enabler.template
@@ -4,7 +4,7 @@ Description: Creates an SNS topic and Lambda function used to enable GuardDuty a
 Parameters:
   SecurityAccountId:
     Type: String
-    Description: Which account will be the GuardDuty Master?  Enter the AWS account ID. (This is generally the AWS Control Tower Audit account)
+    Description: Which account will be the GuardDuty Admin?  Enter the AWS account ID. (This is generally the AWS Control Tower Audit account)
     AllowedPattern: '^[0-9]{12}$'
     ConstraintDescription: The Security Account ID must be a 12 character string.
     MinLength: 12
@@ -128,7 +128,7 @@ Resources:
             assume_role: !Sub ${RoleToAssume}
             region_filter: !Ref RegionFilter
             ct_root_account: !Sub ${AWS::AccountId}
-            master_account: !Sub ${SecurityAccountId}
+            admin_account: !Sub ${SecurityAccountId}
             topic: !Ref GuardDutyEnablerTopic
 
   GuardDutyEnablerTopic:

--- a/aws-control-tower-guardduty-enabler.template
+++ b/aws-control-tower-guardduty-enabler.template
@@ -25,11 +25,11 @@ Parameters:
       - ControlTower
   S3SourceBucket:
     Type: String
-    Description: Which S3 bucket contains the gdinviter37.py.zip file for the GuardDutyEnabler lambda function?
+    Description: Which S3 bucket contains the guardduty_enabler.zip file for the GuardDutyEnabler lambda function?
   S3SourceFile:
     Type: String
     Description: What is the S3 path to the zip file for the GuardDutyEnabler lambda function?
-    Default: gdinviter37.py.zip
+    Default: guardduty_enabler.zip
   ComplianceFrequency:
     Type: Number
     Description: How frequently (in minutes, between 1 and 3600, default is 60) should organizational compliance be checked?


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changes master name references to Admin for GuardDuty admin account, Root for Control Tower central account, and main for primary github branch

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
