### PR TITLE
Enable GuardDuty in all regions for all accounts via cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ __pycache__/
 build/
 develop-eggs/
 dist/
+src/dist/
 downloads/
 eggs/
 .eggs/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Centralize AWS GuardDuty
 
-Installing this Customization will enable GuardDuty in all AWS Control Tower managed accounts, with the Audit account acting as the default GuardDuty Admin account.
+Installing this Customization will enable GuardDuty in all AWS Control Tower managed accounts, with the management delegated to a security account.
 
 This is done by deploying a GuardDuty Enabler lambda function in the Control Tower root account. It runs periodically and checks each Control Tower managed account/region to ensure that they have been invited into the GuardDuty Admin account and that GuardDuty is enabled.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The original code for automating GuardDuty enablement in AWS accounts is present
 1. Gather other information for deployment parameters:
 
     - In AWS Organizations, look on the Settings page for the Organization ID. It will be o-xxxxxxxxxx
-    - In AWS Organizations, look on the Accounts page for the Audit account ID.
+    - In AWS Organizations, look on the Accounts page for the Security Account ID.
 
 1. Launch the CloudFormation stack:  aws-control-tower-guardduty-enabler.template
 

--- a/aws-control-tower-guardduty-enabler.template
+++ b/aws-control-tower-guardduty-enabler.template
@@ -4,7 +4,7 @@ Description: Creates an SNS topic and Lambda function used to enable GuardDuty a
 Parameters:
   SecurityAccountId:
     Type: String
-    Description: Which account will be the GuardDuty Admin?  Enter the AWS account ID. (This is generally the AWS Control Tower Audit account)
+    Description: Which account will be the GuardDuty Admin?  Enter the AWS account ID.
     AllowedPattern: '^[0-9]{12}$'
     ConstraintDescription: The Security Account ID must be a 12 character string.
     MinLength: 12
@@ -19,7 +19,7 @@ Parameters:
   RegionFilter:
     Type: String
     Description: Should GuardDuty be enabled for all GuardDuty supported regions, or only Control Tower supported regions?
-    Default: ControlTower
+    Default: GuardDuty
     AllowedValues:
       - GuardDuty
       - ControlTower
@@ -32,8 +32,8 @@ Parameters:
     Default: guardduty_enabler.zip
   ComplianceFrequency:
     Type: Number
-    Description: How frequently (in minutes, between 1 and 3600, default is 60) should organizational compliance be checked?
-    Default: 60
+    Description: How frequently (in minutes, between 1 and 3600, default is 1440 - 24hrs) should organizational compliance be checked?
+    Default: 1440
     MinValue: 1
     MaxValue: 3600
     ConstraintDescription: Compliance Frequency must be a number between 1 and 3600, inclusive.

--- a/aws-control-tower-guardduty-enabler.template
+++ b/aws-control-tower-guardduty-enabler.template
@@ -49,19 +49,19 @@ Parameters:
     ConstraintDescription: Lambda Log Retention must be a number between 1 (1 day) and 3653 (10 years). Valid values are 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 2192, 2557, 2922, 3288, and 3653.
 
 Resources:
-  GuardDutyEnablerRole: 
+  GuardDutyEnablerRole:
     Type: AWS::IAM::Role
-    Properties: 
-      AssumeRolePolicyDocument: 
+    Properties:
+      AssumeRolePolicyDocument:
         Version: 2012-10-17
-        Statement: 
-          - 
+        Statement:
+          -
             Effect: Allow
-            Principal: 
-              Service: 
+            Principal:
+              Service:
                 - lambda.amazonaws.com
             Action: sts:AssumeRole
-      Policies: 
+      Policies:
       - PolicyName: GuardDutyEnablerPolicy
         PolicyDocument:
           Version: 2012-10-17
@@ -88,13 +88,13 @@ Resources:
               - logs:CreateLogGroup
               - logs:CreateLogStream
               - logs:PutLogEvents
-            Resource: 
+            Resource:
               -  !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*
           - Effect: Allow
             Action: CloudFormation:ListStackInstances
             Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stackset/AWSControlTowerBP-BASELINE-CLOUDWATCH:*
           - Effect: Allow
-            Action: 
+            Action:
               - iam:GetRole
               - iam:CreateServiceLinkedRole
             Resource: '*'
@@ -119,10 +119,10 @@ Resources:
           - id: W11
             reason: "Organizations doesn't have arns, so we have to use an asterisk in the policy"
 
-  GuardDutyEnablerLambda: 
+  GuardDutyEnablerLambda:
     DependsOn: GuardDutyEnablerRole
     Type: AWS::Lambda::Function
-    Properties: 
+    Properties:
       Handler: guardduty_enabler.lambda_handler
       Role: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${GuardDutyEnablerRole}
       Code:
@@ -168,46 +168,46 @@ Resources:
       Protocol: lambda
       TopicArn: !Ref GuardDutyEnablerTopic
 
-  GDScheduledRule: 
+  GDScheduledRule:
     Type: AWS::Events::Rule
-    Properties: 
+    Properties:
       Description: GuardDutyScheduledComplianceTrigger
       ScheduleExpression: !Sub rate(${ComplianceFrequency} minutes)
       State: ENABLED
-      Targets: 
-        - 
+      Targets:
+        -
           Arn: !GetAtt GuardDutyEnablerLambda.Arn
           Id: DailyInvite
 
-  GDLifeCycleRule: 
+  GDLifeCycleRule:
     Type: AWS::Events::Rule
-    Properties: 
+    Properties:
       Description: GuardDutyLifeCycleTrigger
       EventPattern:
-        source: 
+        source:
           - aws.controltower
-        detail-type: 
+        detail-type:
           - AWS Service Event via CloudTrail
         detail:
           eventName:
             - CreateManagedAccount
       State: ENABLED
-      Targets: 
-        - 
+      Targets:
+        -
           Arn: !GetAtt GuardDutyEnablerLambda.Arn
           Id: DailyInvite
 
-  GuardDutyEnablerPermissionForEventsToInvokeLambda: 
+  GuardDutyEnablerPermissionForEventsToInvokeLambda:
     Type: AWS::Lambda::Permission
-    Properties: 
+    Properties:
       FunctionName: !GetAtt GuardDutyEnablerLambda.Arn
       Action: lambda:InvokeFunction
       Principal: events.amazonaws.com
       SourceArn: !GetAtt GDScheduledRule.Arn
 
-  GuardDutyEnablerPermissionForLifecycleEventsToInvokeLambda: 
+  GuardDutyEnablerPermissionForLifecycleEventsToInvokeLambda:
     Type: AWS::Lambda::Permission
-    Properties: 
+    Properties:
       FunctionName: !GetAtt GuardDutyEnablerLambda.Arn
       Action: lambda:InvokeFunction
       Principal: events.amazonaws.com

--- a/aws-control-tower-guardduty-enabler.template
+++ b/aws-control-tower-guardduty-enabler.template
@@ -32,8 +32,8 @@ Parameters:
     Default: guardduty_enabler.zip
   ComplianceFrequency:
     Type: Number
-    Description: How frequently (in minutes, between 1 and 3600, default is 1440 - 24hrs) should organizational compliance be checked?
-    Default: 1440
+    Description: How frequently (in minutes, between 1 and 3600, default is 60) should organizational compliance be checked?
+    Default: 60
     MinValue: 1
     MaxValue: 3600
     ConstraintDescription: Compliance Frequency must be a number between 1 and 3600, inclusive.

--- a/aws-control-tower-guardduty-enabler.template
+++ b/aws-control-tower-guardduty-enabler.template
@@ -19,7 +19,7 @@ Parameters:
   RegionFilter:
     Type: String
     Description: Should GuardDuty be enabled for all GuardDuty supported regions, or only Control Tower supported regions?
-    Default: GuardDuty
+    Default: ControlTower
     AllowedValues:
       - GuardDuty
       - ControlTower

--- a/aws-control-tower-guardduty-enabler.template
+++ b/aws-control-tower-guardduty-enabler.template
@@ -45,8 +45,7 @@ Parameters:
     Type: Number
     Description: How long (in days, between 1 and 3653, default is 30) should CloudWatch logs for the GuardDutyEnabler lambda function be retained?
     Default: 30
-    MinValue: 1
-    MaxValue: 3653
+    AllowedValues: ['1', '3', '5', '7', '14', '30', '60', '90', '120', '150', '180', '365', '400', '545', '731', '1827', '2192', '2557', '2922', '3288', '3653']
     ConstraintDescription: Lambda Log Retention must be a number between 1 (1 day) and 3653 (10 years). Valid values are 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 2192, 2557, 2922, 3288, and 3653.
 
 Resources:

--- a/aws-control-tower-guardduty-enabler.template
+++ b/aws-control-tower-guardduty-enabler.template
@@ -41,6 +41,13 @@ Parameters:
     Type: String
     Default: AWSControlTowerExecution
     Description: What role should be assumed in child accounts to enable GuardDuty?  The default is AWSControlTowerExecution for a Control Tower Environment.
+  LambdaLogRetenion:
+    Type: Number
+    Description: How long (in days, between 1 and 3653, default is 30) should CloudWatch logs for the GuardDutyEnabler lambda function be retained?
+    Default: 30
+    MinValue: 1
+    MaxValue: 3653
+    ConstraintDescription: Lambda Log Retention must be a number between 1 (1 day) and 3653 (10 years). Valid values are 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 2192, 2557, 2922, 3288, and 3653.
 
 Resources:
   GuardDutyEnablerRole: 
@@ -134,6 +141,12 @@ Resources:
             topic: !Ref GuardDutyEnablerTopic
             log_level: "ERROR"
 
+  GuardDutyEnablerLambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${GuardDutyEnablerLambda}"
+      RetentionInDays: !Ref LambdaLogRetenion
+
   GuardDutyEnablerTopic:
     Type: AWS::SNS::Topic
     Properties:
@@ -206,6 +219,7 @@ Resources:
       - GuardDutyEnablerRole
       - GuardDutyEnablerTopicLambdaPermission
       - GuardDutyEnablerSubscription
+      - GuardDutyEnablerLambdaLogGroup
     Type: Custom::GuardDutyEnablerLambdaFirstRun
     Properties:
       ServiceToken: !GetAtt GuardDutyEnablerLambda.Arn

--- a/aws-control-tower-guardduty-enabler.template
+++ b/aws-control-tower-guardduty-enabler.template
@@ -143,6 +143,7 @@ Resources:
 
   GuardDutyEnablerLambdaLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
     Properties:
       LogGroupName: !Sub "/aws/lambda/${GuardDutyEnablerLambda}"
       RetentionInDays: !Ref LambdaLogRetenion

--- a/src/enable_guardduty.sh
+++ b/src/enable_guardduty.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Function to log errors
+log_error() {
+  echo "ERROR: $1" >&2
+}
+
+# Function to enable GuardDuty in a region
+enable_guardduty() {
+  local region=$1
+  local profile=$2
+  local admin_account_id=$3
+
+  delegated_administrator=$(aws-vault exec "$profile" -- aws guardduty list-organization-admin-accounts --region $region | jq -r '.AdminAccounts[].AdminStatus')
+
+  if [ "$delegated_administrator" != "ENABLED" ]; then
+    if aws-vault exec "$profile" -- aws guardduty enable-organization-admin-account \
+      --admin-account-id "$admin_account_id" --region "$region" 2>> "$ERROR_LOG"; then
+      echo "GuardDuty enabled for region $region"
+    else
+      log_error "Failed to enable GuardDuty for region $region"
+    fi
+  else
+    echo "GuardDuty already enabled in $region"
+  fi
+}
+
+# Function to enable GuardDuty auto-enable organization members for a region
+enable_guardduty_auto_enable() {
+  local region=$1
+  local profile=$2
+  local detector=$3
+
+  org_config=$(aws-vault exec "$profile" -- aws guardduty describe-organization-configuration \
+    --detector-id "$detector" --region "$region" | jq -r '.AutoEnable')
+
+  if [ "$org_config" != "true" ]; then
+    echo "Starting with $region and detector $detector"
+    if aws-vault exec "$profile" -- aws guardduty update-organization-configuration \
+      --detector-id "$detector" --auto-enable-organization-members ALL --region "$region" 2>> "$ERROR_LOG"; then
+      while read -r account_number email; do
+        aws-vault exec "$profile" -- aws guardduty create-members \
+          --detector-id "$detector" --account-details "AccountId=$account_number,Email=$email" --region "$region" > /dev/null 2>> "$ERROR_LOG"
+      done < <(echo "$accounts_json" | jq -r '.Accounts[] | "\(.Id) \(.Email)"')
+      echo "Auto-enabled is now enabled for $region, and member accounts have been added"
+    else
+      log_error "Failed to auto-enable organization members for detector $detector in region $region"
+    fi
+  else
+    echo "Auto Enable already configured for region $region"
+  fi
+}
+
+# Main Script
+set -e
+
+read -rp "Enter regions governed by Control Tower (separated by spaces): " -a GOVERNED_REGIONS
+read -rp "Enter security account ID: " SECURITY_ACCOUNT_ID
+read -rp "Enter the aws-vault profile for the management account: " MANAGEMENT_PROFILE
+read -rp "Enter the aws-vault profile for the security account: " SECURITY_PROFILE
+
+# Retrieve list of member accounts in Organization
+accounts_json=$(aws-vault exec testcontroltower_main -- aws organizations list-accounts)
+
+# Define a log file for error messages
+ERROR_LOG="guardduty_errors.log"
+
+# Enable trusted access for GuardDuty from AWS Organizations
+if aws-vault exec "$MANAGEMENT_PROFILE" -- aws organizations enable-aws-service-access \
+  --service-principal guardduty.amazonaws.com 2>> "$ERROR_LOG"; then
+  echo "Trusted access enabled for GuardDuty"
+else
+  log_error "Failed to enable trusted access, error log is available in $ERROR_LOG"
+fi
+
+# Enable GuardDuty in active regions
+for region in "${GOVERNED_REGIONS[@]}"; do
+  enable_guardduty "$region" "$MANAGEMENT_PROFILE" "$SECURITY_ACCOUNT_ID"
+done
+
+# Retrieve detectors for each region
+for region in "${GOVERNED_REGIONS[@]}"; do
+  detector=$(aws-vault exec "$SECURITY_PROFILE" -- aws guardduty list-detectors --region "$region" | jq -r '.DetectorIds[]' 2>> "$ERROR_LOG")
+  enable_guardduty_auto_enable "$region" "$SECURITY_PROFILE" "$detector"
+done

--- a/src/guardduty_enabler.py
+++ b/src/guardduty_enabler.py
@@ -531,3 +531,4 @@ def lambda_handler(event, context):
                 json.dumps(failed_accounts, sort_keys=True, default=str)))
     except Exception as e:
         LOGGER.error("Exception: %s" % (str(e)))
+        send(event, context, 'FAILED', {})

--- a/src/guardduty_enabler.py
+++ b/src/guardduty_enabler.py
@@ -1,4 +1,4 @@
-""" 
+"""
 Copyright 2020 Amazon.com, Inc. or its affiliates.
 All Rights Reserved.
 

--- a/src/guardduty_enabler.py
+++ b/src/guardduty_enabler.py
@@ -25,7 +25,6 @@ import os
 import time
 import logging
 import urllib3
-import cfnresponse
 from botocore.exceptions import ClientError
 
 LOGGER = logging.getLogger()
@@ -528,8 +527,7 @@ def lambda_handler(event, context):
                         LOGGER.debug(f"Finished {account} in {aws_region}")
 
         if len(failed_accounts) > 0:
-            LOGGER.info("Error Processing following accounts: %s" % (
+            LOGGER.error("Error Processing following accounts: %s" % (
                 json.dumps(failed_accounts, sort_keys=True, default=str)))
-        cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
-    except Exception:
-        cfnresponse.send(event, context, cfnresponse.FAILED, {})
+    except Exception as e:
+        LOGGER.error("Exception: %s" % (str(e)))

--- a/src/package.sh
+++ b/src/package.sh
@@ -8,7 +8,7 @@ set -x
 SCRIPT_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 pushd $SCRIPT_DIRECTORY > /dev/null
- 
+
 rm -f guardduty_enabler.zip > /dev/null 2>&1
 
 zip guardduty_enabler.zip guardduty_enabler.py

--- a/src/package.sh
+++ b/src/package.sh
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
- 
 # Builds a lambda package from a single Python 3 module with pip dependencies.
 # This is a modified version of the AWS packaging instructions:
 # https://docs.aws.amazon.com/lambda/latest/dg/lambda-python-how-to-create-deployment-package.html#python-package-dependencies
- 
+
+set -e
+set -x
+
 # https://stackoverflow.com/a/246128
 SCRIPT_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+rm -rf ${SCRIPT_DIRECTORY}/dist
+
+mkdir ${SCRIPT_DIRECTORY}/dist
+cp ${SCRIPT_DIRECTORY}/guardduty_enabler.py ${SCRIPT_DIRECTORY}/dist
+cp ${SCRIPT_DIRECTORY}/requirements.txt ${SCRIPT_DIRECTORY}/dist
+
+docker run -w /build/src/dist -v ${PWD}:/build -ti python:3.7 /usr/local/bin/pip3 install --target . -r requirements.txt
  
-pushd $SCRIPT_DIRECTORY > /dev/null
- 
-rm -rf .package guardduty_enabler.zip
-#mkdir .package
- 
-# pip3 install --target .package --requirement requirements.txt
- 
-#pushd .package > /dev/null
-#zip --recurse-paths ${SCRIPT_DIRECTORY}/guardduty_enabler.zip .
-#popd > /dev/null
- 
-zip --grow  guardduty_enabler.zip guardduty_enabler.py
+pushd ${SCRIPT_DIRECTORY}/dist > /dev/null
+
+zip --grow  guardduty_enabler.zip *
  
 popd > /dev/null

--- a/src/package.sh
+++ b/src/package.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-# Builds a lambda package from a single Python 3 module with pip dependencies.
-# This is a modified version of the AWS packaging instructions:
-# https://docs.aws.amazon.com/lambda/latest/dg/lambda-python-how-to-create-deployment-package.html#python-package-dependencies
+# Builds a lambda package, a zip with a single Python file
 
 set -e
 set -x
@@ -9,16 +7,10 @@ set -x
 # https://stackoverflow.com/a/246128
 SCRIPT_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-rm -rf ${SCRIPT_DIRECTORY}/dist
-
-mkdir ${SCRIPT_DIRECTORY}/dist
-cp ${SCRIPT_DIRECTORY}/guardduty_enabler.py ${SCRIPT_DIRECTORY}/dist
-cp ${SCRIPT_DIRECTORY}/requirements.txt ${SCRIPT_DIRECTORY}/dist
-
-docker run -w /build/src/dist -v ${PWD}:/build -ti python:3.7 /usr/local/bin/pip3 install --target . -r requirements.txt
+pushd $SCRIPT_DIRECTORY > /dev/null
  
-pushd ${SCRIPT_DIRECTORY}/dist > /dev/null
+rm -f guardduty_enabler.zip > /dev/null 2>&1
 
-zip --grow  guardduty_enabler.zip *
- 
+zip guardduty_enabler.zip guardduty_enabler.py
+
 popd > /dev/null

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,1 +1,2 @@
 boto3
+cfnresponse

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,1 @@
 boto3
-cfnresponse


### PR DESCRIPTION
#### *[Trello card](https://trello.com/c/otVSSM8H)*

#### *Summary*
Using the GuardDuty service integration with AWS Organizations member accounts can be automatically added to GuardDuty when added to AWS Organizations. Previously a Lambda function was required to enable GuardDuty in all the active regions for all the member accounts. This function also had to run on a schedule to check for any new accounts so that they could also be added. 

#### *Description of changes:*
Shell script to check and enable GuarDuty in all active regions and to set auto-enable on GuardDuty in the security account to active using the available AWS CLI commands.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
